### PR TITLE
refactor:improve lexer impl with idiomatic rust patterns

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,35 +1,40 @@
 use crate::TOKEN;
 
-pub fn lex_expr(expr: &String) -> Vec<TOKEN> {
-    let mut vector: Vec<TOKEN> = Vec::new();
+pub fn lex_expr( expr: &str ) -> Vec<TOKEN> {
+    let mut tokens = Vec::new();
     let mut chars = expr.chars().peekable();
-
-    while let Some(ch) = chars.next() {
+    
+    while let Some( ch ) = chars.next() {
         match ch {
-            '0'..'9' => {
-                let mut num = ch.to_string();
-
-                while let Some(next_ch) = chars.peek() {
-                    if next_ch.is_ascii_digit() || *next_ch == '.' {
-                        num.push(chars.next().unwrap());
+            '0'..='9' => {
+                let mut num = String::from( ch );
+                let mut has_dot = false;
+                
+                while let Some( &next_ch ) = chars.peek() {
+                    if next_ch.is_ascii_digit() {
+                        num.push( chars.next().unwrap() );
+                    } else if next_ch == '.' && !has_dot {
+                        has_dot = true;
+                        num.push( chars.next().unwrap() );
                     } else {
                         break;
                     }
                 }
-
-                let num = num.parse::<f64>().unwrap();
-                vector.push(TOKEN::NUMBER(num));
+                
+                if let Ok( value ) = num.parse::<f64>() {
+                    tokens.push( TOKEN::NUMBER( value ) );
+                }
             }
-            ' ' => continue,
-            '(' => vector.push(TOKEN::LPAREN),
-            ')' => vector.push(TOKEN::RPAREN),
-            '+' => vector.push(TOKEN::PLUS),
-            '-' => vector.push(TOKEN::MINUS),
-            '*' => vector.push(TOKEN::MULTIPLY),
-            '/' => vector.push(TOKEN::DIVIDE),
-            _ => ()
+            ' ' | '\t' | '\n' | '\r' => continue,
+            '(' => tokens.push( TOKEN::LPAREN ),
+            ')' => tokens.push( TOKEN::RPAREN ),
+            '+' => tokens.push( TOKEN::PLUS ),
+            '-' => tokens.push( TOKEN::MINUS ),
+            '*' => tokens.push( TOKEN::MULTIPLY ),
+            '/' => tokens.push( TOKEN::DIVIDE ),
+            _ => {}
         }
     }
-
-    vector
+    
+    tokens
 }


### PR DESCRIPTION
improves `lexer.rs` with several rust best practices and bug fixes:

- change parameter from `&String` to `&str` (idiomatic, avoids allocation constraints)
- prevent multiple decimal points in number literals via `has_dot` flag
- proper error handling on `parse()` with `if let Ok` instead of `unwrap()`
- handle all whitespace characters (`\t`, `\n`, `\r`) not just space
- use inclusive range `'0'..='9'` syntax
- cleaner variable naming (`tokens` instead of `vector`)

fixes potential panic on malformed input and prevents invalid number parsing like `1.2.3`